### PR TITLE
feat: Adicionar eventos ao Google Calendar

### DIFF
--- a/index.css
+++ b/index.css
@@ -117,7 +117,7 @@ footer a {
 
 @media screen and (max-width: 600px) {
   body {
-    font-size: 0.9em;
+    font-size: 0.7em;
   }
 
   .header {

--- a/index.html
+++ b/index.html
@@ -45,11 +45,11 @@
             <th colspan="5">Programação</th>
           </tr>
           <tr>
-            <th>Data</th>
+            <th style="width: 5%">Data</th>
             <th>Hora</th>
-            <th>Atividade</th>
+            <th style="width: 50%">Atividade</th>
             <th>Cursos</th>
-            <th></th>
+            <th style="width: 5%"></th>
           </tr>
         </thead>
         <tbody>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
       integrity="sha384-LTIDeidl25h2dPxrB2Ekgc9c7sEC3CWGM6HeFmuDNUjX76Ert4Z4IY714dhZHPLd"
       crossorigin="anonymous"
     />
-    <script src="index.js"></script>
+    <script src="index.js" async defer></script>
     <link rel="stylesheet" href="index.css" />
   </head>
   <body>
@@ -42,108 +42,109 @@
       <table class="pure-table pure-table-horizontal pure-table-bordered">
         <thead>
           <tr>
-            <th colspan="4">Programação</th>
+            <th colspan="5">Programação</th>
           </tr>
           <tr>
             <th>Data</th>
             <th>Hora</th>
             <th>Atividade</th>
             <th>Cursos</th>
+            <th></th>
           </tr>
         </thead>
         <tbody>
           <tr>
-            <td colspan="4" class="meta">
+            <td colspan="5" class="meta">
               Sala Virtual:
               <a href="https://meet.google.com/hks-iafq-dqn">
-                meet.google.com/hks-iafq-dqn
+                https://meet.google.com/hks-iafq-dqn
               </a>
             </td>
           </tr>
-          <tr>
+          <tr class="event">
             <td rowspan="5" class="date">15/03</td>
             <td>08:00</td>
             <td>Apresentação FACOM/Coordenadores</td>
             <td>EC e CC</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>09:30</td>
             <td>Ferramentas Institucionais / Ensino Remoto de Emergência</td>
             <td>EC e CC</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>13:30</td>
             <td>Apresentação FACOM/Coordenadores</td>
             <td>ES</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>18:30</td>
             <td>Apresentação FACOM/Coordenadores</td>
             <td>SI</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>20:00</td>
             <td>Ferramentas Institucionais / Ensino Remoto de Emergência</td>
             <td>ES e SI</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td rowspan="6" class="date">16/03</td>
             <td>08:00</td>
             <td>Grupos PET</td>
             <td rowspan="3">EC e CC</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>09:00</td>
             <td>Atlética / Mega</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>10:00</td>
             <td>Laboratórios</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>18:00</td>
             <td>Grupos PET</td>
             <td rowspan="3">ES e SI</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>19:00</td>
             <td>Atlética / Mega</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>20:00</td>
             <td>Laboratórios</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td rowspan="3" class="date">17/03</td>
             <td>08:00</td>
             <td>Computação (prof. Edson Cáceres)</td>
             <td rowspan="3">Todos</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>09:00</td>
             <td>Pesquisa (prof. Edson Takashi)</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>10:00</td>
             <td>Estágios (profa. Jucele)</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td rowspan="2" class="date">18/03</td>
             <td>08:00</td>
             <td>Liga Acadêmica (prof. Amaury)</td>
             <td rowspan="2">Todos</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>09:00</td>
             <td>SBC (profa. Valéria)</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td rowspan="2" class="date">19/03</td>
             <td>16:00</td>
             <td>Oficinas (PETs)</td>
             <td rowspan="2">Todos</td>
           </tr>
-          <tr>
+          <tr class="event">
             <td>18:00</td>
             <td>Atividades Recreativas</td>
           </tr>
@@ -151,7 +152,7 @@
       </table>
     </section>
     <section id="links">
-      <span class="links-title">Links Úteis</span>
+      <span class="links-title">Links Importantes</span>
       <ul>
         <li>
           Passaporte UFMS:

--- a/index.js
+++ b/index.js
@@ -12,8 +12,9 @@ const createReminderAnchor = ({ title, details, start, end }) => {
     const calendarStart = dateToCalendarDate(start)
     const calendarEnd = dateToCalendarDate(end)
     const reminderId = calendarStart + calendarEnd
+    const icon = window.localStorage.getItem(reminderId) === 'true' ? createSolidBellIcon(reminderId) : createBellIcon(reminderId)
 
-    return `<td><a onclick="toggleReminder('${reminderId}')" href="https://calendar.google.com/calendar/u/0/r/eventedit?text=${title}&details=${details}&dates=${calendarStart}/${calendarEnd}&ctz=America/Campo_Grande" target="_blank">${createBellIcon(reminderId)}</a></td>`
+    return `<td><a onclick="toggleReminder('${reminderId}')" href="https://calendar.google.com/calendar/u/0/r/eventedit?text=${title}&details=${details}&dates=${calendarStart}/${calendarEnd}&ctz=America/Campo_Grande" target="_blank">${icon}</a></td>`
 }
 
 // Troca o estado do botão de adicionar notificação

--- a/index.js
+++ b/index.js
@@ -1,0 +1,114 @@
+// Criação do icone de notificação
+// https://heroicons.com/
+const createBellIcon = reminderId => `<svg id="${reminderId}" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="#a0a0a0" width="20px"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"/></svg>`
+const createSolidBellIcon = reminderId => `<svg id="${reminderId}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="#a0a0a0" width="20px"><path d="M10 2a6 6 0 00-6 6v3.586l-.707.707A1 1 0 004 14h12a1 1 0 00.707-1.707L16 11.586V8a6 6 0 00-6-6zM10 18a3 3 0 01-3-3h6a3 3 0 01-3 3z" /></svg>`
+
+// Conversão de uma data JavaScript para o formato de data do Google Calendar (Ymd\\THi00\\Z)
+const dateToCalendarDate = date => date.toISOString().replace(/-|:|\./g, "")
+
+// Criação do link com a URL do evento no Google Calendar
+// O _reminderId_ é gerado a partir da timestamps de início + fim do evento (que nesse caso, é único)
+const createReminderAnchor = ({ title, details, start, end }) => {
+    const calendarStart = dateToCalendarDate(start)
+    const calendarEnd = dateToCalendarDate(end)
+    const reminderId = calendarStart + calendarEnd
+
+    return `<td><a onclick="toggleReminder('${reminderId}')" href="https://calendar.google.com/calendar/u/0/r/eventedit?text=${title}&details=${details}&dates=${calendarStart}/${calendarEnd}&ctz=America/Campo_Grande" target="_blank">${createBellIcon(reminderId)}</a></td>`
+}
+
+// Troca o estado do botão de adicionar notificação
+// Utiliza o _localStorage_ para armazenar esse estado
+const toggleReminder = reminderId => {
+    const reminderValue = window.localStorage.getItem(reminderId)
+    const nextReminderValue = reminderValue === 'true' ? 'false' : 'true'
+    const nextReminderElement = reminderValue === 'true' ? createBellIcon(reminderId) : createSolidBellIcon(reminderId)
+
+    window.localStorage.setItem(reminderId, nextReminderValue)
+    document.getElementById(reminderId).parentNode.innerHTML = nextReminderElement
+}
+
+// Converte uma data do tipo "dd/mm" e uma hora em uma data JavaScript
+const parseDate = (date, hour) => {
+    const dateParts = date.split("/")
+    const hourParts = hour.split(":")
+
+    return new Date(
+        (new Date()).getFullYear(),
+        parseInt(dateParts[1], 10) - 1,
+        parseInt(dateParts[0], 10),
+        parseInt(hourParts[0]),
+        parseInt(hourParts[1])
+    )
+}
+
+const events = document.getElementsByClassName('event')
+
+// Helper para auxiliar na identificação do formato dos dados na linha na tabela
+const isEventWithDate = eventChildren => eventChildren[0].classList.contains('date')
+const isEventWithCourses = eventChildren => isEventWithDate(eventChildren) ? eventChildren.length === 4 : eventChildren.length === 3
+
+const getDataFromEvent = event => {
+    const children = Array.from(event.children)
+
+    const courses = isEventWithCourses(children) && children[children.length - 1].innerHTML
+
+    const isWithData = isEventWithDate(children)
+
+    const [c1, c2, c3] = children
+
+    const date = isWithData && c1.innerHTML
+    const hour = isWithData ? c2.innerHTML : c1.innerHTML
+    const title = isWithData ? c3.innerHTML : c2.innerHTML
+
+    return {
+        courses,
+        hour,
+        title,
+        date
+    }
+}
+
+function main() {
+    let lastDate, lastCourses;
+
+    Array.from(events).forEach((event, eventIndex) => {
+        const { courses, hour, title, date } = getDataFromEvent(event)
+
+        lastCourses = courses || lastCourses
+        lastDate = date || lastDate
+
+        const start = parseDate(lastDate, hour)
+
+        const nextEvent = events.length > eventIndex + 1 && events[eventIndex + 1]
+
+        // Se não existir um próximo evento, o horário final será
+        // de 1h após o início do evento, por padrão.
+
+        let end
+
+        if (nextEvent) {
+            const nextEventData = getDataFromEvent(nextEvent)
+            end = parseDate(nextEventData.date || lastDate, nextEventData.hour)
+        } else {
+            const startClone = new Date(start)
+            startClone.setHours(start.getHours() + 1)
+
+            end = startClone
+        }
+
+        const reminderAnchor = createReminderAnchor({
+            title,
+            details: `Evento para as turmas de ${lastCourses}`,
+            start,
+            end,
+        })
+
+        event.insertAdjacentHTML('beforeend', reminderAnchor)
+    })
+}
+
+main()
+
+
+
+


### PR DESCRIPTION
Essa PR tem como objetivo possibilitar que os calouros(as) adicionem os eventos ao seu [_Google Calendar_](https://calendar.google.com/calendar), disponível através da conta de e-mail institucional da UFMS (que é uma conta Google), para que eles não percam os eventos de seu interesse. Assim, estimulamos os alunos a organizarem seus horários, algo que acredito ser essencial nesse cenário de ensino remoto.

#### Botões para a criação dos eventos
![pr-1](https://user-images.githubusercontent.com/7810622/110891114-b7483e80-82c7-11eb-92d2-98f5ff436312.PNG)

#### Eventos criados no _Google Calendar_
![pr-2](https://user-images.githubusercontent.com/7810622/110891194-e2cb2900-82c7-11eb-9f1d-979d359b3b48.PNG)

#### Botões "ativados" indicando eventos que o calouro se interessou
![pr-3](https://user-images.githubusercontent.com/7810622/110891307-202fb680-82c8-11eb-994e-b5a059be708a.PNG)

A motivação por trás da PR foi apoiar/participar do projeto por achar uma iniciativa muito legal. Qualquer feedback é bem vindo. 
